### PR TITLE
Update DCGM Diagnostics response handling to support newer versions of DCGM

### DIFF
--- a/PBS_scripts/nvidia_cleanup_groups
+++ b/PBS_scripts/nvidia_cleanup_groups
@@ -1,4 +1,5 @@
 #!/bin/python
+# -*- coding: utf-8 -*-
 
 #
 # Copyright (C) 1994-2019 Altair Engineering, Inc.

--- a/PBS_scripts/nvidia_cleanup_groups
+++ b/PBS_scripts/nvidia_cleanup_groups
@@ -60,7 +60,7 @@ except:
         
 
 def show_usage():
-    print 'Usage: %s -g <grp_id list>' % os.path.basename(sys.argv[0])
+    print('Usage: %s -g <grp_id list>' % os.path.basename(sys.argv[0]))
 
 
 try:
@@ -107,10 +107,10 @@ def cleanup(grpIds):
         dcgmHandle = None
 
     else:
-        print "Module import error"
+        print("Module import error")
 
 
 cleanup(group_ids)
 
-print "Cleaned up group ids:",group_ids
+print("Cleaned up group ids:",group_ids)
 

--- a/PBS_scripts/nvidia_diagnostic_check
+++ b/PBS_scripts/nvidia_diagnostic_check
@@ -60,7 +60,7 @@ except:
         
 
 def show_usage():
-    print 'Usage: %s -i <gpu_id list>' % os.path.basename(sys.argv[0])
+    print('Usage: %s -i <gpu_id list>' % os.path.basename(sys.argv[0]))
 
 
 try:
@@ -114,7 +114,7 @@ def diagnose(grpName, gpuIds):
 
         ## Debug: Invoke method to get gpu IDs of the members of the newly-created group
         #groupGpuIds = dcgmGroup.GetGpuIds()
-    
+
         ## This will go ahead and perform a "prologue" diagnostic
         ## to make sure everything is ready to run
         ## currently this calls an outside diagnostic binary but eventually
@@ -122,24 +122,51 @@ def diagnose(grpName, gpuIds):
         ## The "response" is a dcgmDiagResponse structure that can be parsed for errors.
         response = dcgmGroup.action.RunDiagnostic(dcgm_structs.DCGM_DIAG_LVL_SHORT)
 
-        if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.blacklist):
-            health_info.append('blacklist')
-        if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.nvmlLibrary):
-            health_info.append('nvmlLibrary')
-        if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.cudaMainLibrary):
-            health_info.append('cudaMainLibrary')
-        #if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.cudaRuntimeLibrary):
-            #    health_info.append('cudaRuntimeLibrary')
-        if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.permissions):
-            health_info.append('permissions')
-        #if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.persistenceMode):
-            #    health_info.append('persistenceMode')
-        #if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.environment):
-            #    health_info.append('environment')
-        #if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.pageRetirement):
-            #    health_info.append('pageRetirement')
-        #if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.graphicsProcesses):
-            #    health_info.append('graphicsProcesses')                
+        ## DCGM encodes the version of structures as a bitshifted value
+        ## bitwise ORed with the size of the structure
+        dcgm_diagnostic_version= int((response.version & (255 << 24)) >> 24)
+
+
+        if (dcgm_diagnostic_version >= 4):
+            if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.levelOneResults[dcgm_structs.DCGM_SWTEST_BLACKLIST].result):
+                health_info.append('blacklist')
+            if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.levelOneResults[dcgm_structs.DCGM_SWTEST_NVML_LIBRARY].result):
+                health_info.append('nvmlLibrary')
+            if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.levelOneResults[dcgm_structs.DCGM_SWTEST_CUDA_MAIN_LIBRARY].result):
+                health_info.append('cudaMainLibrary')
+            #if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.levelOneResults[dcgm_structs.DCGM_SWTEST_CUDA_RUNTIME_LIBRARY].result):
+                #    health_info.append('cudaRuntimeLibrary')
+            if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.levelOneResults[dcgm_structs.DCGM_SWTEST_PERMISSIONS].result):
+                health_info.append('permissions')
+            #if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.levelOneResults[dcgm_structs.DCGM_SWTEST_PERSISTENCE_MODE].result):
+                #    health_info.append('persistenceMode')
+            #if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.levelOneResults[dcgm_structs.DCGM_SWTEST_ENVIRONMENT].result):
+                #    health_info.append('environment')
+            #if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.levelOneResults[dcgm_structs.DCGM_SWTEST_PAGE_RETIREMENT].result):
+                #    health_info.append('pageRetirement')
+            #if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.levelOneResults[dcgm_structs.DCGM_SWTEST_GRAPHICS_PROCESSES].result):
+                #    health_info.append('graphicsProcesses')                
+            if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.levelOneResults[dcgm_structs.DCGM_SWTEST_INFOROM].result):
+                health_info.append('inforom')
+        else:
+            if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.blacklist):
+                health_info.append('blacklist')
+            if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.nvmlLibrary):
+                health_info.append('nvmlLibrary')
+            if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.cudaMainLibrary):
+                health_info.append('cudaMainLibrary')
+            #if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.cudaRuntimeLibrary):
+                #    health_info.append('cudaRuntimeLibrary')
+            if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.permissions):
+                health_info.append('permissions')
+            #if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.persistenceMode):
+                #    health_info.append('persistenceMode')
+            #if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.environment):
+                #    health_info.append('environment')
+            #if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.pageRetirement):
+                #    health_info.append('pageRetirement')
+            #if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.graphicsProcesses):
+                #    health_info.append('graphicsProcesses')                
     
         delete_group(health_info, dcgmGroup)
     else:
@@ -149,5 +176,5 @@ def diagnose(grpName, gpuIds):
 for i in range(len(gpu_ids)):
     diagnose("gpu-diag-test", gpu_ids[i])
 
-print json.dumps(health_info)
+print(json.dumps(health_info))
 

--- a/PBS_scripts/nvidia_diagnostic_check
+++ b/PBS_scripts/nvidia_diagnostic_check
@@ -1,4 +1,5 @@
 #!/bin/python
+# -*- coding: utf-8 -*-
 
 #
 # Copyright (C) 1994-2019 Altair Engineering, Inc.

--- a/PBS_scripts/nvidia_get_resources_used
+++ b/PBS_scripts/nvidia_get_resources_used
@@ -1,4 +1,5 @@
 #!/bin/python
+# -*- coding: utf-8 -*-
 
 #
 # Copyright (C) 1994-2019 Altair Engineering, Inc.

--- a/PBS_scripts/nvidia_get_resources_used
+++ b/PBS_scripts/nvidia_get_resources_used
@@ -54,7 +54,7 @@ import dcgmvalue
 
         
 def show_usage():
-    print 'Usage: %s -g <gpu_id list> -j <job id> -r <resource list>' % os.path.basename(sys.argv[0])
+    print('Usage: %s -g <gpu_id list> -j <job id> -r <resource list>' % os.path.basename(sys.argv[0]))
 
 try:
     opts, args = getopt.getopt(sys.argv[1:], 'G:j:r:')
@@ -242,5 +242,5 @@ resource_string = '+'.join(gpus_info)
 
 delete_group(handleObj, groupObj)
 
-print json.dumps(resource_string)
+print(json.dumps(resource_string))
 

--- a/PBS_scripts/nvidia_health_check
+++ b/PBS_scripts/nvidia_health_check
@@ -1,4 +1,5 @@
 #!/bin/python
+# -*- coding: utf-8 -*-
 
 #
 # Copyright (C) 1994-2019 Altair Engineering, Inc.

--- a/PBS_scripts/nvidia_health_check
+++ b/PBS_scripts/nvidia_health_check
@@ -122,5 +122,5 @@ else:
 output['health'] = health
 output['comment'] = comment
 
-print json.dumps(output)
+print(json.dumps(output))
 

--- a/PBS_scripts/nvidia_start_gpu_monitoring
+++ b/PBS_scripts/nvidia_start_gpu_monitoring
@@ -54,7 +54,7 @@ import dcgmvalue
 
         
 def show_usage():
-    print 'Usage: %s -g <gpu_id list> -j <job id> -w <walltime secs>' % os.path.basename(sys.argv[0])
+    print('Usage: %s -g <gpu_id list> -j <job id> -w <walltime secs>' % os.path.basename(sys.argv[0]))
 
 try:
     opts, args = getopt.getopt(sys.argv[1:], 'g:j:w:')
@@ -79,8 +79,8 @@ if not (gpu_list and job_id and walltime_secs):
     sys.exit(1)
 
     
-#print 'gpu_list', gpu_list
-#print 'job_id', job_id
+#print('gpu_list', gpu_list)
+#print('job_id', job_id)
 
 
 def setup_dcgm_group(group_name, gpus):
@@ -96,7 +96,7 @@ def setup_dcgm_group(group_name, gpus):
         groupObj.AddGpu(int(gpu))
     
     gpuIds = groupObj.GetGpuIds() 
-    #print 'gpuIds %s' % (gpuIds)
+    #print('gpuIds %s' % (gpuIds))
     
     return handleObj, groupObj
     
@@ -108,5 +108,5 @@ groupObj.stats.WatchJobFields(1000000, int(walltime_secs), 0)
 # Notify DCGM to start collecting stats
 groupObj.stats.StartJobStats(job_id)
 
-print str(groupObj.GetId().value)
+print(str(groupObj.GetId().value))
 

--- a/PBS_scripts/nvidia_start_gpu_monitoring
+++ b/PBS_scripts/nvidia_start_gpu_monitoring
@@ -1,4 +1,5 @@
 #!/bin/python
+# -*- coding: utf-8 -*-
 
 #
 # Copyright (C) 1994-2019 Altair Engineering, Inc.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Various parameters are captured as mentioned in the config json file of the hook
 The following prerequisites must be met.
 
 - The Integration package supports PBS version 18.x or 19.x. PBS 2020 not integrate, yet.
-- DCGM v1.3.3 or later is installed. DCGM v2.x not integrated, yet. 
+- DCGM v1.3.3 or later is installed. 
 - datacenter-gpu-manager-375.41-1.x86_64.rpm or higher is installed with all the necessary NVIDIA packages.
 - nv-hostengine is running.
 - A shared directory location across the compute nodes and PBS server node.

--- a/resource_framework_hook.py
+++ b/resource_framework_hook.py
@@ -136,7 +136,7 @@ if os.path.isfile(os.environ['PBS_CONF_FILE']):
             os.environ[line.split('=')[0]] = line.split('=')[1].strip('\n')
     pbs_conf.close()
 else:
-    print 'Unable to find PBS_CONF_FILE ... ' + os.environ['PBS_CONF_FILE']
+    print('Unable to find PBS_CONF_FILE ... ' + os.environ['PBS_CONF_FILE'])
     sys.exit(1)
 
 pbsExec = os.environ['PBS_EXEC']
@@ -484,34 +484,71 @@ class ngpus(resource):
             ## The "response" is a dcgmDiagResponse structure that can be parsed for errors.
             response = dcgmGroup.action.RunDiagnostic(dcgm_structs.DCGM_DIAG_LVL_SHORT)
             #pbs.logmsg(pbs.EVENT_DEBUG, "response %s" % (response))
-                    
-            if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.blacklist):
-                pbs.logmsg(pbs.EVENT_DEBUG, "Failed blacklist")
-                health_info.append('blacklist')
-            if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.nvmlLibrary):
-                pbs.logmsg(pbs.EVENT_DEBUG, "Failed nvmlLibrary")
-                health_info.append('nvmlLibrary')
-            if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.cudaMainLibrary):
-                pbs.logmsg(pbs.EVENT_DEBUG, "Failed cudaMainLibrary")
-                health_info.append('cudaMainLibrary')
-            #if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.cudaRuntimeLibrary):
-            #    pbs.logmsg(pbs.EVENT_DEBUG, "Failed cudaRuntimeLibrary")
-            #    health_info.append('cudaRuntimeLibrary')
-            if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.permissions):
-                pbs.logmsg(pbs.EVENT_DEBUG, "Failed permissions")
-                health_info.append('permissions')
-            if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.persistenceMode):
-                pbs.logmsg(pbs.EVENT_DEBUG, "Failed persistenceMode")
-                health_info.append('persistenceMode')
-            if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.environment):
-                pbs.logmsg(pbs.EVENT_DEBUG, "Failed environment")
-                health_info.append('environment')
-            if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.pageRetirement):
-                pbs.logmsg(pbs.EVENT_DEBUG, "Failed pageRetirement")
-                health_info.append('pageRetirement')
-            if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.graphicsProcesses):
-                pbs.logmsg(pbs.EVENT_DEBUG, "Failed graphicsProcesses")
-                health_info.append('graphicsProcesses')
+
+            ## DCGM encodes the version of structures as a bitshifted value
+            ## bitwise ORed with the size of the structure
+            dcgm_diagnostic_version= int((response.version & (255 << 24)) >> 24)
+
+
+            if (dcgm_diagnostic_version >= 4):
+                if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.levelOneResults[dcgm_structs.DCGM_SWTEST_BLACKLIST].result):
+                    pbs.logmsg(pbs.EVENT_DEBUG, "Failed blacklist")
+                    health_info.append('blacklist')
+                if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.levelOneResults[dcgm_structs.DCGM_SWTEST_NVML_LIBRARY].result):
+                    pbs.logmsg(pbs.EVENT_DEBUG, "Failed nvmlLibrary")
+                    health_info.append('nvmlLibrary')
+                if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.levelOneResults[dcgm_structs.DCGM_SWTEST_CUDA_MAIN_LIBRARY].result):
+                    pbs.logmsg(pbs.EVENT_DEBUG, "Failed cudaMainLibrary")
+                    health_info.append('cudaMainLibrary')
+                #if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.levelOneResults[dcgm_structs.DCGM_SWTEST_CUDA_RUNTIME_LIBRARY].result):
+                #    pbs.logmsg(pbs.EVENT_DEBUG, "Failed cudaRuntimeLibrary")
+                #    health_info.append('cudaRuntimeLibrary')
+                if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.levelOneResults[dcgm_structs.DCGM_SWTEST_PERMISSIONS].result):
+                    pbs.logmsg(pbs.EVENT_DEBUG, "Failed permissions")
+                    health_info.append('permissions')
+                if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.levelOneResults[dcgm_structs.DCGM_SWTEST_PERSISTENCE_MODE].result):
+                    pbs.logmsg(pbs.EVENT_DEBUG, "Failed persistenceMode")
+                    health_info.append('persistenceMode')
+                if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.levelOneResults[dcgm_structs.DCGM_SWTEST_ENVIRONMENT].result):
+                    pbs.logmsg(pbs.EVENT_DEBUG, "Failed environment")
+                    health_info.append('environment')
+                if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.levelOneResults[dcgm_structs.DCGM_SWTEST_PAGE_RETIREMENT].result):
+                    pbs.logmsg(pbs.EVENT_DEBUG, "Failed pageRetirement")
+                    health_info.append('pageRetirement')
+                if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.levelOneResults[dcgm_structs.DCGM_SWTEST_GRAPHICS_PROCESSES].result):
+                    pbs.logmsg(pbs.EVENT_DEBUG, "Failed graphicsProcesses")
+                    health_info.append('graphicsProcesses')
+                if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.levelOneResults[dcgm_structs.DCGM_SWTEST_INFOROM].result):
+                    pbs.logmsg(pbs.EVENT_DEBUG, "Failed inforom")
+                    health_info.append('inforom')
+            else:                     
+                if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.blacklist):
+                    pbs.logmsg(pbs.EVENT_DEBUG, "Failed blacklist")
+                    health_info.append('blacklist')
+                if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.nvmlLibrary):
+                    pbs.logmsg(pbs.EVENT_DEBUG, "Failed nvmlLibrary")
+                    health_info.append('nvmlLibrary')
+                if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.cudaMainLibrary):
+                    pbs.logmsg(pbs.EVENT_DEBUG, "Failed cudaMainLibrary")
+                    health_info.append('cudaMainLibrary')
+                #if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.cudaRuntimeLibrary):
+                #    pbs.logmsg(pbs.EVENT_DEBUG, "Failed cudaRuntimeLibrary")
+                #    health_info.append('cudaRuntimeLibrary')
+                if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.permissions):
+                    pbs.logmsg(pbs.EVENT_DEBUG, "Failed permissions")
+                    health_info.append('permissions')
+                if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.persistenceMode):
+                    pbs.logmsg(pbs.EVENT_DEBUG, "Failed persistenceMode")
+                    health_info.append('persistenceMode')
+                if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.environment):
+                    pbs.logmsg(pbs.EVENT_DEBUG, "Failed environment")
+                    health_info.append('environment')
+                if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.pageRetirement):
+                    pbs.logmsg(pbs.EVENT_DEBUG, "Failed pageRetirement")
+                    health_info.append('pageRetirement')
+                if (dcgm_structs.DCGM_DIAG_RESULT_PASS !=  response.graphicsProcesses):
+                    pbs.logmsg(pbs.EVENT_DEBUG, "Failed graphicsProcesses")
+                    health_info.append('graphicsProcesses')
         
     
             self.delete_group(dcgmHandle, dcgmGroup)
@@ -945,9 +982,9 @@ class ngpus(resource):
     
     
     def convert_dcgmStatSummaryInt32_t(self, info):
-        print 'convert_dcgmStatSummaryInt32_t'
-        print 'info', info
-        print 'info.minValue', info.minValue
+        print('convert_dcgmStatSummaryInt32_t')
+        print('info', info)
+        print('info.minValue', info.minValue)
         data = {}
         if self.get_defined_value(info.minValue) != None: data['minValue'] = info.minValue
         if self.get_defined_value(info.maxValue) != None: data['maxValue'] = info.maxValue


### PR DESCRIPTION
Fixes #8 by detecting version of diagnostic response from DCGM and retrieving necessary information from the response depending on the version. Tested utilizing OpenPBS 19.1.3 and Nvidia DCGM 2.0.13.

Additionally updated print statements in various files to Python 3 compliance.  